### PR TITLE
Allow a guard to be passed into the recieveTestRequest 

### DIFF
--- a/src/EMR.php
+++ b/src/EMR.php
@@ -27,7 +27,7 @@ class EMR {
     }
 
     // receive and add test request on queue
-    public function receiveTestRequest(Request $request)
+    public function receiveTestRequest(Request $request, $guard = null)
     {
         $rules = [
             'subject' => 'required',
@@ -64,7 +64,7 @@ class EMR {
                     $patient->name_id = $name->id;
                     $patient->gender_id = $gender->id;
                     $patient->birth_date = $request->input('subject.birthDate');
-                    $patient->created_by = Auth::user()->id;
+                    $patient->created_by = Auth::guard($guard)->user()->id;
                     $patient->save();
                 }
 
@@ -87,7 +87,7 @@ class EMR {
                     $test->identifier = $request->input('subject.identifier');// using patient for now
                     $test->test_type_id = $item['test_type_id'];
                     $test->test_status_id = TestStatus::pending;
-                    $test->created_by = Auth::user()->id;
+                    $test->created_by = Auth::guard($guard)->user()->id;
                     $test->requested_by = $request->input('orderer.name');// practitioner
                     $test->save();
 


### PR DESCRIPTION
This should allow custom guards to be used in the case where a user implementation has multiple guards. The guard name would be passed as an argument else guard will be null and the default guard would be used.